### PR TITLE
[PLAT-71] Pass volume variable to tf_ecs_task_definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ END
 ### Outputs
 
 * `arn` - the ARN of the task definition.
+* `task_role_arn` - the ARN of the Role for this task definition.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ module "taskdef" {
 }
 END
 
+    volume = {
+        name = 'data'
+        host_path = '/mnt/data'
+    }
 }
 ```
 
@@ -32,7 +36,7 @@ END
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
 * `policy` - An IAM policy to control the task's access to AWS services - see http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
-* `volume` - Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container.
+* `volume` - Volume block map with 'name' and 'host_path'. See https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume for more info.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ END
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
 * `policy` - An IAM policy to control the task's access to AWS services - see http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
+* `volume` - Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container.
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "task_definition" {
-    source                = "github.com/mergermarket/tf_ecs_task_definition"
+    source                = "github.com/mergermarket/tf_ecs_task_definition?ref=PLAT-71_add_volume_2"
     family                = "${var.family}"
     container_definitions = "${var.container_definitions}"
     task_role_arn         = "${aws_iam_role.task_role.arn}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "task_definition" {
-  source                = "github.com/mergermarket/tf_ecs_task_definition?ref=PLAT-71_add_volume_2"
+  source                = "github.com/mergermarket/tf_ecs_task_definition"
   family                = "${var.family}"
   container_definitions = "${var.container_definitions}"
   task_role_arn         = "${aws_iam_role.task_role.arn}"

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ module "task_definition" {
     family                = "${var.family}"
     container_definitions = "${var.container_definitions}"
     task_role_arn         = "${aws_iam_role.task_role.arn}"
+    volume                = "${var.volume}"
 }
 
 resource "aws_iam_role_policy" "role_policy" {

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,20 @@
 module "task_definition" {
-    source                = "github.com/mergermarket/tf_ecs_task_definition?ref=PLAT-71_add_volume_2"
-    family                = "${var.family}"
-    container_definitions = "${var.container_definitions}"
-    task_role_arn         = "${aws_iam_role.task_role.arn}"
-    volume                = "${var.volume}"
+  source                = "github.com/mergermarket/tf_ecs_task_definition?ref=PLAT-71_add_volume_2"
+  family                = "${var.family}"
+  container_definitions = "${var.container_definitions}"
+  task_role_arn         = "${aws_iam_role.task_role.arn}"
+  volume                = "${var.volume}"
 }
 
 resource "aws_iam_role_policy" "role_policy" {
-    name_prefix = "${var.family}"
-    role        = "${aws_iam_role.task_role.id}"
-    policy      = "${var.policy}"
+  name_prefix = "${var.family}"
+  role        = "${aws_iam_role.task_role.id}"
+  policy      = "${var.policy}"
 }
 
 resource "aws_iam_role" "task_role" {
-    name_prefix        = "${var.family}"
-    assume_role_policy = "${data.aws_iam_policy_document.instance-assume-role-policy.json}"
+  name_prefix        = "${var.family}"
+  assume_role_policy = "${data.aws_iam_policy_document.instance-assume-role-policy.json}"
 }
 
 data "aws_iam_policy_document" "instance-assume-role-policy" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "arn" {
     value = "${module.task_definition.arn}"
 }
+
+output "task_role_arn" {
+    value = "${aws_iam_role.task_role.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+    value = "${module.task_definition.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-    value = "${module.task_definition.arn}"
+  value = "${module.task_definition.arn}"
 }
 
 output "task_role_arn" {
-    value = "${aws_iam_role.task_role.arn}"
+  value = "${aws_iam_role.task_role.arn}"
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -5,6 +5,8 @@ ENV TERRAFORM_VERSION=0.9.5
 ENV TERRAFORM_ZIP=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ENV TERRAFORM_SUM=0cbb5474c76d878fbc99e7705ce6117f4ea0838175c13b2663286a207e38d783
 
+ENV PYTHONDONTWRITEBYTECODE donot
+
 RUN apk add -U ca-certificates curl git && \
     cd /tmp && \
     curl -fsSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP} && \

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -10,6 +10,12 @@ provider "aws" {
   region                      = "eu-west-1"
 }
 
+variable "task_volume_param" {
+    description = "Allow the test to pass this in"
+    type = "map"
+    default = {}
+}
+
 module "taskdef_with_role" {
     source = "../.."
 
@@ -35,4 +41,6 @@ END
   }
 }
 END
+
+    volume = "${var.task_volume_param}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,17 +11,18 @@ provider "aws" {
 }
 
 variable "task_volume_param" {
-    description = "The test can set this var to be passed to the module"
-    type = "map"
-    default = {}
+  description = "The test can set this var to be passed to the module"
+  type        = "map"
+  default     = {}
 }
 
 module "taskdef_with_role" {
-    source = "../.."
+  source = "../.."
 
-    family                = "tf_ecs_task_def_test_family"
-    container_definitions = [
-        <<END
+  family = "tf_ecs_task_def_test_family"
+
+  container_definitions = [
+    <<END
 {
   "name": "web",
   "image": "hello-world:latest",
@@ -30,8 +31,10 @@ module "taskdef_with_role" {
   "essential": true
 }
 END
-    ]
-    policy                = <<END
+    ,
+  ]
+
+  policy = <<END
 {
   "Version": "2012-10-17",
   "Statement": {
@@ -42,5 +45,5 @@ END
 }
 END
 
-    volume = "${var.task_volume_param}"
+  volume = "${var.task_volume_param}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
 }
 
 variable "task_volume_param" {
-    description = "Allow the test to pass this in"
+    description = "The test can set this var to be passed to the module"
     type = "map"
     default = {}
 }

--- a/test/run
+++ b/test/run
@@ -2,13 +2,6 @@
 
 set -euo pipefail
 
-clean() {
-    rm -rf .terraform/
-    find . -type d -name __pycache__ | xargs rm -rf
-}
-
-trap clean EXIT
-
 repo_dir=$(git rev-parse --show-toplevel)
 name=$(basename $repo_dir)-test
 

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -27,14 +27,45 @@ class TestTaskdefWithRole(unittest.TestCase):
             cwd=self.workdir
         ).decode('utf-8')
 
+        print(output)
+
         expected = dedent("""
             + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
-                arn:                   "<computed>"
-                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
-                family:                "tf_ecs_task_def_test_family"
-                network_mode:          "<computed>"
-                revision:              "<computed>"
-                task_role_arn:         "${var.task_role_arn}"
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "tf_ecs_task_def_test_family"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                task_role_arn:               "${var.task_role_arn}"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
+        """).strip()
+
+        assert expected in output
+
+    def test_task_definition_passes_volume(self):
+        output = check_output([
+            'terraform',
+            'plan', '-no-color',
+            '-var', 'task_volume_param={name="data_volume",host_path="/mnt/data"}',
+            self.module_path],
+            cwd=self.workdir
+        ).decode('utf-8')
+
+        print(output)
+
+        expected = dedent("""
+            + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
+                arn:                       "<computed>"
+                container_definitions:     "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                    "tf_ecs_task_def_test_family"
+                network_mode:              "<computed>"
+                revision:                  "<computed>"
+                task_role_arn:             "${var.task_role_arn}"
+                volume.#:                  "1"
+                volume.27251535.host_path: "/mnt/data"
+                volume.27251535.name:      "data_volume"
         """).strip()
 
         assert expected in output

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -1,9 +1,8 @@
-import unittest
 import os
-import tempfile
 import shutil
-
-from subprocess import check_output, check_call
+import tempfile
+import unittest
+from subprocess import check_call, check_output
 from textwrap import dedent
 
 

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -56,7 +56,7 @@ class TestTaskdefWithRole(unittest.TestCase):
                 name:        "<computed>"
                 name_prefix: "tf_ecs_task_def_test_family"
                 policy:      "{\\n  \\"Version\\": \\"2012-10-17\\",\\n  \\"Statement\\": {\\n    \\"Effect\\": \\"Allow\\",\\n    \\"Action\\": \\"s3:ListBucket\\",\\n    \\"Resource\\": \\"arn:aws:s3:::example_bucket\\"\\n  }\\n}\\n"
-                role:        "${aws_iam_role.task_role.arn}"
+                role:        "${aws_iam_role.task_role.id}"
         """).strip()
 
         assert expected in output

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -1,4 +1,7 @@
 import unittest
+import os
+import tempfile
+import shutil
 
 from subprocess import check_output, check_call
 from textwrap import dedent
@@ -7,14 +10,22 @@ from textwrap import dedent
 class TestTaskdefWithRole(unittest.TestCase):
 
     def setUp(self):
-        check_call(['terraform', 'get', 'test/infra'])
+        self.workdir = tempfile.mkdtemp()
+        self.module_path = os.path.join(os.getcwd(), 'test', 'infra')
+
+        check_call(
+            ['terraform', 'get', self.module_path],
+            cwd=self.workdir)
+
+    def tearDown(self):
+        if os.path.isdir(self.workdir):
+            shutil.rmtree(self.workdir)
 
     def test_task_definition_is_created(self):
         output = check_output(
-            ['terraform', 'plan', '-no-color', 'test/infra']
+            ['terraform', 'plan', '-no-color', self.module_path],
+            cwd=self.workdir
         ).decode('utf-8')
-
-        print(output)
 
         expected = dedent("""
             + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
@@ -30,7 +41,8 @@ class TestTaskdefWithRole(unittest.TestCase):
 
     def test_task_role_is_created(self):
         output = check_output(
-            ['terraform', 'plan', '-no-color', 'test/infra']
+            ['terraform', 'plan', '-no-color', self.module_path],
+            cwd=self.workdir
         ).decode('utf-8')
 
         expected = dedent("""
@@ -48,7 +60,8 @@ class TestTaskdefWithRole(unittest.TestCase):
 
     def test_task_policy_is_created(self):
         output = check_output(
-            ['terraform', 'plan', '-no-color', 'test/infra']
+            ['terraform', 'plan', '-no-color', self.module_path],
+            cwd=self.workdir
         ).decode('utf-8')
 
         expected = dedent("""

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "policy" {
 }
 
 variable "volume" {
-    description = "Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container."
+    description = "Volume block map with 'name' and 'host_path'."
     type = "map"
     default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,20 @@
 variable "family" {
-    description = "A unique name for your task defintion."
-    type        = "string"
+  description = "A unique name for your task defintion."
+  type        = "string"
 }
 
 variable "container_definitions" {
-    description = "A list of valid container definitions provided as a single valid JSON document."
-    type        = "list"
+  description = "A list of valid container definitions provided as a single valid JSON document."
+  type        = "list"
 }
 
 variable "policy" {
-    description = "A valid IAM policy for the task"
-    type        = "string"
+  description = "A valid IAM policy for the task"
+  type        = "string"
 }
 
 variable "volume" {
-    description = "Volume block map with 'name' and 'host_path'."
-    type = "map"
-    default = {}
+  description = "Volume block map with 'name' and 'host_path'."
+  type        = "map"
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "policy" {
     description = "A valid IAM policy for the task"
     type        = "string"
 }
+
+variable "volume" {
+    description = "Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container."
+    type = "map"
+    default = {}
+}


### PR DESCRIPTION
As per https://github.com/mergermarket/tf_ecs_task_definition/pull/3, pass the volume variable to the underlying repository.

We also add the missing output arn.

Dependencies
------------

**IMPORTANT** merge https://github.com/mergermarket/tf_ecs_task_definition/pull/3 then remove the temporary commit pointing to that branch in this repo before merge.