### PR TITLE
[PLAT-71] Use ecs-tasks instead of ec2 for task role policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
+      identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
When using a role with a task definition, the task role policy must have a
policy that allows ecs-tasks.amazonaws.com assume a role.

Using the principal ec2.amazonaws.com is likely wrong, and it should be
ecs-tasks.amazon.com [1]

[1] http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_IAM_role.html