### PR TITLE
PLAT-71: Truncate the task role name_prefix is len() > 32

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,11 @@ resource "aws_iam_role_policy" "role_policy" {
 }
 
 resource "aws_iam_role" "task_role" {
-  name_prefix        = "${var.family}"
+  name_prefix        = "${
+    length(var.family) <= 32 ?
+      var.family :
+      format("%.24stf%.4s", var.family, sha1(var.family))
+  }"
   assume_role_policy = "${data.aws_iam_policy_document.instance-assume-role-policy.json}"
 }
 

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -16,10 +16,15 @@ variable "task_volume_param" {
   default     = {}
 }
 
+variable "family_param" {
+  description = "The test can set this var to be passed to the module"
+  default     = "tf_ecs_task_def_test_family"
+}
+
 module "taskdef_with_role" {
   source = "../.."
 
-  family = "tf_ecs_task_def_test_family"
+  family = "${var.family_param}"
 
   container_definitions = [
     <<END

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -100,3 +100,31 @@ class TestTaskdefWithRole(unittest.TestCase):
         """).strip()
 
         assert expected in output
+
+    def test_task_definition_is_created_when_long_family_name(self):
+        # Given
+        family="a"*33
+
+        output = check_output([
+            'terraform',
+            'plan',
+            '-no-color',
+            '-var', 'family_param={}'.format(family),
+            self.module_path
+        ], cwd=self.workdir
+        ).decode('utf-8')
+
+        expected = dedent("""
+            + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "{family}"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                task_role_arn:               "${{var.task_role_arn}}"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
+        """).strip().format(family=family)
+
+        assert expected in output

--- a/test/test_taskdef_with_role.py
+++ b/test/test_taskdef_with_role.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+
 from subprocess import check_call, check_output
 from textwrap import dedent
 
@@ -25,8 +26,6 @@ class TestTaskdefWithRole(unittest.TestCase):
             ['terraform', 'plan', '-no-color', self.module_path],
             cwd=self.workdir
         ).decode('utf-8')
-
-        print(output)
 
         expected = dedent("""
             + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
@@ -52,8 +51,6 @@ class TestTaskdefWithRole(unittest.TestCase):
             cwd=self.workdir
         ).decode('utf-8')
 
-        print(output)
-
         expected = dedent("""
             + module.taskdef_with_role.task_definition.aws_ecs_task_definition.taskdef
                 arn:                       "<computed>"
@@ -78,7 +75,7 @@ class TestTaskdefWithRole(unittest.TestCase):
         expected = dedent("""
             + module.taskdef_with_role.aws_iam_role.task_role
                 arn:                "<computed>"
-                assume_role_policy: "{\\n  \\"Version\\": \\"2012-10-17\\",\\n  \\"Statement\\": [\\n    {\\n      \\"Sid\\": \\"\\",\\n      \\"Effect\\": \\"Allow\\",\\n      \\"Action\\": \\"sts:AssumeRole\\",\\n      \\"Principal\\": {\\n        \\"Service\\": \\"ec2.amazonaws.com\\"\\n      }\\n    }\\n  ]\\n}"
+                assume_role_policy: "{\\n  \\"Version\\": \\"2012-10-17\\",\\n  \\"Statement\\": [\\n    {\\n      \\"Sid\\": \\"\\",\\n      \\"Effect\\": \\"Allow\\",\\n      \\"Action\\": \\"sts:AssumeRole\\",\\n      \\"Principal\\": {\\n        \\"Service\\": \\"ecs-tasks.amazonaws.com\\"\\n      }\\n    }\\n  ]\\n}"
                 create_date:        "<computed>"
                 name:               "<computed>"
                 name_prefix:        "tf_ecs_task_def_test_family"


### PR DESCRIPTION
In order to avoid an error like this:

* module.lambda_s3_backup.module.s3_backup_taskdef.aws_iam_role.task_role:
  "name_prefix" cannot be longer than 32 characters, name is limited to 64

We replace the name prefix with a truncated + a hash version.