### PR TITLE
Output task role name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "arn" {
 output "task_role_arn" {
   value = "${aws_iam_role.task_role.arn}"
 }
+
+output "task_role_name" {
+  value = "${aws_iam_role.task_role.name}"
+}


### PR DESCRIPTION
This is what's used in a policy attachment, rather than the arn.