### PR TITLE
Fix ecs task execution role name length

### DIFF
--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -40,7 +40,7 @@ variable "env" {
 }
 
 module "taskdef_with_role" {
-  source = "../.."
+  source  = "../.."
   is_test = true
 
   family = "${var.family_param}"
@@ -73,7 +73,7 @@ END
 }
 
 module "taskdef_with_role_and_assume_role" {
-  source = "../.."
+  source  = "../.."
   is_test = true
 
   family = "${var.family_param}"


### PR DESCRIPTION
Error: module.ecs_service.module.taskdef.aws_iam_role.ecs_tasks_execution_role: "name" cannot be longer than 64 characters